### PR TITLE
Added loadHtml

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,25 +35,31 @@ Template.billing.created = function() {
 
 ### HTML Examples
 
-Loading external HTML fragment via a Handlebars helper.
+Our example plain HTML fragment `fragment.html`, assumed to be served in these examples as static content under `public`.
+
+``` html
+<div>I'm text, with a <button>button</button>.</div>
+```
+
+Here's loading our external HTML fragment via a Handlebars helper.
 
 ``` javascript
 Handlebars.registerHelper('loadHtml', function() {
-	var template = Meteor.Loader.loadHtml('/htmlFragment.html','new_template_name');
+	var template = Meteor.Loader.loadHtml('/fragment.html','new_template_name');
 	
-	// here we're passing the current data context of the parent template
+	// here we're passing the current data context of the parent template to our fragment
 	return template(this);
 });
 ```
 
-Loading and inserting into the DOM manually.
+Here's loading the same fragment and inserting into the DOM manually.
 
 ``` javascript
 Meteor.startup(function() { // dom is ready
 	var fragment = Meteor.render(function() {
-		var tpl = Meteor.Loader.loadHtml('/htmlFragment.html','new_template_name');
+		var tpl = Meteor.Loader.loadHtml('/fragment.html','new_template_name');
 		
-		// catch some events
+		// catch an event this time
 		tpl.events({
 			'click button': function() {
 				console.log('hello!');

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ mrt add external-file-loader
 2. Load the library in the template that you'll use it in.
 3. Use the library once it's been loaded.
 
-### Example
+### Script Example
 
 Using [stripe.js](https://js.stripe.com/v2/) as the example. We'll load it into the billing template, and charge people money.
 
@@ -33,11 +33,47 @@ Template.billing.created = function() {
 };
 ```
 
+### HTML Examples
+
+Loading external HTML fragment via a Handlebars helper.
+
+``` javascript
+Handlebars.registerHelper('loadHtml', function() {
+	var template = Meteor.Loader.loadHtml('/htmlFragment.html','new_template_name');
+	
+	// here we're passing the current data context of the parent template
+	return template(this);
+});
+```
+
+Loading and inserting into the DOM manually.
+
+``` javascript
+Meteor.startup(function() { // dom is ready
+	var fragment = Meteor.render(function() {
+		var tpl = Meteor.Loader.loadHtml('/htmlFragment.html','new_template_name');
+		
+		// catch some events
+		tpl.events({
+			'click button': function() {
+				console.log('hello!');
+			}
+		});
+		
+		return tpl();
+	});
+	
+	$('#inserthere').html(fragment);
+});
+```
+
 ### Methods
 
  - `loadJs(url, callback)` - Load external JS from a url. Callback is called once the url has been loaded.
 
  - `loadCss(url)` - Load external CSS from a url.
+ 
+ - `loadHtml(url, template_name)` - Load external HTML file from URL and instantiate as template. Returns the template object that's also under the Template namespace (`Template['template_name']`). Handlebar expressions won't work when loading HTML this way.
  
 ## Contributing
 

--- a/lib/external-file-loader.js
+++ b/lib/external-file-loader.js
@@ -42,25 +42,23 @@
 	}
 	
 	Loader.prototype.loadHtml = function(url,template_name) {
-		if(Template[template_name])
+		if(Template[template_name]) {
 			return Template[template_name];
+		}
 	
 		var raw = '';
-		if(typeof url !== "string")
-			raw = url();
-		else
-			$.ajax({
-				url:    url,
-				success: function(html) {
-					raw = html;
-				},
-				async:false
-			});
+		this.ajax({
+			url:    url,
+			success: function(html) {
+				raw = html;
+			},
+			async:false
+		});
 			
 		return Meteor._def_template(template_name, function() {
 			return raw;
 		})();
-	},
+	}
 
 	Loader.prototype.loaded = function(url) {
 		var self = this;
@@ -71,6 +69,9 @@
 	Loader.prototype.resetUrls = function() {
 		this.loadedUrls = {};
 	}
+	
+	// Override for stub during testing
+	Loader.prototype.ajax = jQuery.ajax
 
 	Meteor.Loader = new Loader();
 

--- a/lib/external-file-loader.js
+++ b/lib/external-file-loader.js
@@ -46,13 +46,17 @@
 			return Template[template_name];
 	
 		var raw = '';
-		$.ajax({
-			url:    url,
-			success: function(html) {
-				raw = html;
-			},
-			async:false
-		});
+		if(typeof url !== "string")
+			raw = url();
+		else
+			$.ajax({
+				url:    url,
+				success: function(html) {
+					raw = html;
+				},
+				async:false
+			});
+			
 		return Meteor._def_template(template_name, function() {
 			return raw;
 		})();

--- a/lib/external-file-loader.js
+++ b/lib/external-file-loader.js
@@ -57,7 +57,7 @@
 			
 		return Meteor._def_template(template_name, function() {
 			return raw;
-		})();
+		});
 	}
 
 	Loader.prototype.loaded = function(url) {

--- a/lib/external-file-loader.js
+++ b/lib/external-file-loader.js
@@ -40,6 +40,23 @@
 
 		self.loadedUrls[url] = true;
 	}
+	
+	Loader.prototype.loadHtml = function(url,template_name) {
+		if(Template[template_name])
+			return Template[template_name];
+	
+		var raw = '';
+		$.ajax({
+			url:    url,
+			success: function(html) {
+				raw = html;
+			},
+			async:false
+		});
+		return Meteor._def_template(template_name, function() {
+			return raw;
+		})();
+	},
 
 	Loader.prototype.loaded = function(url) {
 		var self = this;

--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-	summary: "The External File Loader package helps easily load external js and css files dynamically."
+	summary: "The External File Loader package helps easily load external js, css and html files dynamically."
 });
 
 Package.on_use(function (api) {
@@ -7,16 +7,15 @@ Package.on_use(function (api) {
 	api.use('underscore', 'client');
 	api.add_files([
 		'lib/external-file-loader.js'
-	],
-	'client');
-});
+		],
+		'client');
+	});
 
-Package.on_test(function (api) {
-	api.use('external-file-loader', 'client');
-	api.use('tinytest', 'client');
-	api.use('test-helpers', 'client');
-	api.add_files([
-		'test/external-file-loader-test.js'
-	],
-	'client');
+	Package.on_test(function (api) {
+		api.use('external-file-loader', 'client');
+		api.use('tinytest', 'client');
+		api.use('test-helpers', 'client');
+		api.add_files([
+			'test/external-file-loader-test.js'
+		], 'client');
 });

--- a/test/external-file-loader-test.js
+++ b/test/external-file-loader-test.js
@@ -46,10 +46,13 @@ Tinytest.add('loadHtml Real Test', function(test) {
 	Meteor.Loader.resetUrls();
 	test.equal(Meteor.Loader.loadedUrls, {});
 	
-	var url = 'https://raw.github.com/sterlingwes/meteor-external-file-loader/master/test/test.html';
-	var tpl = Meteor.Loader.loadHtml(url,'test_tpl');
+	var urlStub = function() {
+			return '<div>Test</div>';
+		},
+		
+		tpl = Meteor.Loader.loadHtml(urlStub,'test_tpl');
 	
 	test.isTrue(Template['test_tpl']);
 	test.equal(Template['test_tpl'](), '<div>Test</div>');
-	test.equal(Template['test_tpl'], Meteor.Loader.loadHtml(url,'test_tpl'));
+	test.equal(Template['test_tpl'], Meteor.Loader.loadHtml(urlStub,'test_tpl'));
 });

--- a/test/external-file-loader-test.js
+++ b/test/external-file-loader-test.js
@@ -41,3 +41,15 @@ Tinytest.add('loadCss Simple Test', function(test) {
 	test.isTrue(Meteor.Loader.loaded(url));
 	test.isFalse(Meteor.Loader.loadCss(url));
 });
+
+Tinytest.add('loadHtml Real Test', function(test) {
+	Meteor.Loader.resetUrls();
+	test.equal(Meteor.Loader.loadedUrls, {});
+	
+	var url = 'https://raw.github.com/sterlingwes/meteor-external-file-loader/master/test/test.html';
+	var tpl = Meteor.Loader.loadHtml(url,'test_tpl');
+	
+	test.isTrue(Template['test_tpl']);
+	test.equal(Template['test_tpl'](), '<div>Test</div>');
+	test.equal(Template['test_tpl'], Meteor.Loader.loadHtml(url,'test_tpl'));
+});

--- a/test/external-file-loader-test.js
+++ b/test/external-file-loader-test.js
@@ -43,16 +43,13 @@ Tinytest.add('loadCss Simple Test', function(test) {
 });
 
 Tinytest.add('loadHtml Real Test', function(test) {
-	Meteor.Loader.resetUrls();
-	test.equal(Meteor.Loader.loadedUrls, {});
-	
-	var urlStub = function() {
-			return '<div>Test</div>';
-		},
-		
-		tpl = Meteor.Loader.loadHtml(urlStub,'test_tpl');
+	Meteor.Loader.ajax = function(opts) {
+		opts.success('<div>Test</div>');
+	};
+
+	var tpl = Meteor.Loader.loadHtml('/test/testhtml','test_tpl');
 	
 	test.isTrue(Template['test_tpl']);
 	test.equal(Template['test_tpl'](), '<div>Test</div>');
-	test.equal(Template['test_tpl'], Meteor.Loader.loadHtml(urlStub,'test_tpl'));
+	test.equal(Template['test_tpl'], Meteor.Loader.loadHtml('/test/testhtml','test_tpl'));
 });

--- a/test/test.html
+++ b/test/test.html
@@ -1,0 +1,1 @@
+<div>Test</div>

--- a/test/test.html
+++ b/test/test.html
@@ -1,1 +1,0 @@
-<div>Test</div>


### PR DESCRIPTION
Enables loading plain HTML fragments from external sources (ie: public/ static directory) for situations where conditional loading is more appropriate than bundling for all.

HTML is instantiated as a Meteor Template and added to the Template namespace to allow for binding events, etc.

Considering ways to allow use of Handlebar expressions which requires a form of precompiled Handlebar templates for Meteor's Handlebar runtime implementation.
