### PR TITLE
Update for Meteor 0.6.5 compatability

### DIFF
--- a/lib/external-file-loader.js
+++ b/lib/external-file-loader.js
@@ -55,7 +55,7 @@
 			async:false
 		});
 			
-		return Meteor._def_template(template_name, function() {
+		return Template.__define__(template_name, function() {
 			return raw;
 		});
 	}

--- a/package.js
+++ b/package.js
@@ -5,17 +5,18 @@ Package.describe({
 Package.on_use(function (api) {
 	api.use('jquery', 'client');
 	api.use('underscore', 'client');
+	api.use('templating', 'client');
 	api.add_files([
 		'lib/external-file-loader.js'
 		],
 		'client');
 	});
 
-	Package.on_test(function (api) {
-		api.use('external-file-loader', 'client');
-		api.use('tinytest', 'client');
-		api.use('test-helpers', 'client');
-		api.add_files([
-			'test/external-file-loader-test.js'
-		], 'client');
+Package.on_test(function (api) {
+	api.use('external-file-loader', 'client');
+	api.use('tinytest', 'client');
+	api.use('test-helpers', 'client');
+	api.add_files([
+		'test/external-file-loader-test.js'
+	], 'client');
 });

--- a/smart.json
+++ b/smart.json
@@ -4,6 +4,6 @@
 	"homepage": "https://github.com/davidd8/meteor-external-file-loader",
 	"author": "@davidd8 <http://www.davidexmachina.com>",
 	"version": "0.1.2",
-	"git": "https://github.com/davidd8/meteor-external-file-loader.git",
+	"git": "https://github.com/sterlingwes/meteor-external-file-loader.git",
 	"packages": {}
 }

--- a/smart.json
+++ b/smart.json
@@ -4,6 +4,6 @@
 	"homepage": "https://github.com/davidd8/meteor-external-file-loader",
 	"author": "@davidd8 <http://www.davidexmachina.com>",
 	"version": "0.1.2",
-	"git": "https://github.com/sterlingwes/meteor-external-file-loader.git",
+	"git": "https://github.com/davidd8/meteor-external-file-loader.git",
 	"packages": {}
 }


### PR DESCRIPTION
Following 0.6.5 namespace changes, template definition call in loadHtml method now `Template.__define__` from `Meteor._def_template`. Also adds `templating` package requirement.
