### PR TITLE
Add error handling to #loadJs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ Template.billing.created = function() {
 };
 ```
 
+The method returns a [jQuery promise](http://api.jquery.com/deferred.promise/), for easy error handling in case the script cannot be loaded.
+
+The request times out after a while in case the script cannot be found. The default is 5000ms, but is customizable:
+
+``` javascript
+// These 2 calls are equivalent, and set a 10s timeout
+Meteor.Loader.loadJs("//www.google.com/jsapi", sucessCallback, 10000).fail(retryMessageCallback)
+Meteor.Loader.loadJs("//www.google.com/jsapi", 10000).fail(retryMessageCallback).done(successCallback);
+```
+
 ### HTML Examples
 
 Our example plain HTML fragment `fragment.html`, assumed to be served in these examples as static content under `public`.
@@ -75,7 +85,7 @@ Meteor.startup(function() { // dom is ready
 
 ### Methods
 
- - `loadJs(url, callback)` - Load external JS from a url. Callback is called once the url has been loaded.
+ - `loadJs(url, callback, timeoutDelay)` - Load external JS from a url. Callback is called once the url has been loaded. TimeoutDelay is the delay before timeout, in ms. Callback and timeoutDelay are optional. The method returns a [jQuery promise](http://api.jquery.com/deferred.promise/).
 
  - `loadCss(url)` - Load external CSS from a url.
  

--- a/lib/external-file-loader.js
+++ b/lib/external-file-loader.js
@@ -7,8 +7,16 @@
 	}
 
 	// Callback must be of the jquery success callback form: function(data, textStatus, jqxhr)
-	Loader.prototype.loadJs = function(url, callback) {
-		var self = this;
+	Loader.prototype.loadJs = function(url, callback, timeoutDelay) {
+		var self = this,
+			timeoutId,
+			promise;
+
+		if (typeof callback === 'number') {
+			timeoutId = callback;
+		} else if (typeof timeoutDelay !== 'number') {
+			timeoutDelay = 5000
+		}
 
 		// Prevent duplicate URLs from being loaded.
 		if (self.loaded(url)) {
@@ -17,12 +25,21 @@
 
 		self.loadedUrls[url] = false;
 
-		$.getScript(url, function(data, textStatus, jqxhr) {
+		promise = $.getScript(url, function(data, textStatus, jqxhr) {
 			self.loadedUrls[url] = true;
+			clearTimeout(timeoutId);
 			if (callback) {
 				callback(data, textStatus, jqxhr);
 			}
 		});
+
+		// $.getScript doesn't reject promises with cross-domain so we need a timeout
+		// cf. http://stackoverflow.com/questions/1406537/handling-errors-in-jquery-getscript#answer-11741631
+		timeoutId = setTimeout(function() {
+			promise.abort();
+		}, timeoutDelay);
+
+		return promise;
 	}
 
 	Loader.prototype.loadCss = function(url) {

--- a/lib/external-file-loader.js
+++ b/lib/external-file-loader.js
@@ -7,6 +7,8 @@
 	}
 
 	// Callback must be of the jquery success callback form: function(data, textStatus, jqxhr)
+	// timeoutDelay is the number of ms before the script request times out. Default is 5000
+	// If the second arg is a number instead of a callback, it will be considered the timeoutDelay
 	Loader.prototype.loadJs = function(url, callback, timeoutDelay) {
 		var self = this,
 			timeoutId,

--- a/lib/external-file-loader.js
+++ b/lib/external-file-loader.js
@@ -36,7 +36,7 @@
 		// $.getScript doesn't reject promises with cross-domain so we need a timeout
 		// cf. http://stackoverflow.com/questions/1406537/handling-errors-in-jquery-getscript#answer-11741631
 		timeoutId = setTimeout(function() {
-			promise.abort();
+			promise.abort("Timeout error: The script was not found or took too long to load.");
 		}, timeoutDelay);
 
 		return promise;

--- a/test/external-file-loader-test.js
+++ b/test/external-file-loader-test.js
@@ -38,7 +38,8 @@ Tinytest.addAsync('crossdomain loadJs with promises', function(test, expect) {
 		test.isTrue(false);
 		expect();
 	};
-	var called = function() {
+	var called = function(status) {
+		test.equal(status.statusText, "Timeout error: The script was not found or took too long to load.");
 		test.isTrue(true);
 		expect();
 	};

--- a/test/external-file-loader-test.js
+++ b/test/external-file-loader-test.js
@@ -29,6 +29,38 @@ Tinytest.addAsync('loadJs Real Test', function(test, expect) {
 	Meteor.Loader.loadJs(realUrl, cb);
 });
 
+Tinytest.addAsync('crossdomain loadJs with promises', function(test, expect) {
+	Meteor.Loader.resetUrls();
+	// test non-existing cross-domain url
+	var fakeUrl = "http://this.url.wont/point/to/anything123.js";
+	test.isFalse(Meteor.Loader.loaded(fakeUrl));
+	var notCalled = function() {
+		test.isTrue(false);
+		expect();
+	};
+	var called = function() {
+		test.isTrue(true);
+		expect();
+	};
+	Meteor.Loader.loadJs(fakeUrl, 2000).fail(called).done(notCalled);
+});
+
+Tinytest.addAsync('local loadJs with promises', function(test, expect) {
+	Meteor.Loader.resetUrls();
+	// test non-existing cross-domain url
+	var fakeUrl = "anything123.js";
+	test.isFalse(Meteor.Loader.loaded(fakeUrl));
+	var notCalled = function() {
+		test.isTrue(false);
+		expect();
+	};
+	var called = function() {
+		test.isTrue(true);
+		expect();
+	};
+	Meteor.Loader.loadJs(fakeUrl).fail(called).done(notCalled);
+});
+
 Tinytest.add('loadCss Simple Test', function(test) {
 	Meteor.Loader.resetUrls();
 	test.equal(Meteor.Loader.loadedUrls, {});
@@ -48,7 +80,7 @@ Tinytest.add('loadHtml Real Test', function(test) {
 	};
 
 	var tpl = Meteor.Loader.loadHtml('/test/testhtml','test_tpl');
-	
+
 	test.isTrue(Template['test_tpl']);
 	test.equal(Template['test_tpl'](), '<div>Test</div>');
 	test.equal(Template['test_tpl'], Meteor.Loader.loadHtml('/test/testhtml','test_tpl'));


### PR DESCRIPTION
Hi,

Thanks a lot for `meteor-external-file-loader`, very useful.

I needed a way to handle error cases (e.g. display an error/retry message to the user if I can't process because they got disconnected or something went wrong with the lib's loading)

Turns out `jQuery.getScript` already returns a promise, so it's pretty straightforward to allow error handling to your lib's user with something like that:

``` js
Loader.prototype.loadJs('url', successCallback, 10000).fail(errorCallback)
```

Thought it might be useful to other people too.
